### PR TITLE
DEVOPS-341: fix error with hash parameters

### DIFF
--- a/lib/omniauth/strategies/password.rb
+++ b/lib/omniauth/strategies/password.rb
@@ -26,7 +26,7 @@ module OmniAuth
 
       def login
         if request[:sessions]
-          request[:sessions][options[:login_field].to_s].send(options[:login_transform])
+          request[:sessions][options[:login_field].to_s].to_s.send(options[:login_transform])
         else
           ''
         end


### PR DESCRIPTION
Somehow arguments are being treated as hashes here and we have a config option to call `downcase` instead of `to_s` on it for the `login_transform` transform option. I don't know of a "to_s and downcase" method so I added an always `to_s` call here. I tried to use a lambda or proc, but those don't work with `send`. The other option would be to monkey patch a "to_s and downcase" method onto the Object class in aha-app, but in support of trying to avoid monkey patching I added the `to_s` call here instead.