### PR TITLE
A-12234: Handle users logging in with password that have none set

### DIFF
--- a/lib/omniauth/strategies/password.rb
+++ b/lib/omniauth/strategies/password.rb
@@ -12,7 +12,7 @@ module OmniAuth
       end
 
       def callback_phase
-        return fail!(:invalid_credentials) unless user.try(:authenticate, password)
+        return fail!(:invalid_credentials) unless user && uid && user.authenticate(password)
         super
       end
 


### PR DESCRIPTION
Account for users with nil passwords

Original pr discussion here: https://github.com/aha-app/aha-app/pull/18726

* [Sentry error](https://sentry.io/organizations/aha-labs-inc/issues/2397528039/activity/?project=139823&query=logger%3Aruby+is%3Aunresolved&sort=user&statsPeriod=14d)